### PR TITLE
#446: Updated access checks to allow view_all permission access to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [2.0.3]
+
+- Gave users with `view_any` submission permission access to API.
+
 ## [2.0.2]
 
 - Added `OS2Forms Attachment` to attachments data.
@@ -32,7 +36,8 @@ about writing changes to this log.
 
 - Release 1.0.0
 
-[Unreleased]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.0.2...HEAD
+[Unreleased]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.0.3...HEAD
+[2.0.3]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.0.2...2.0.3
 [2.0.2]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.0.1...2.0.2
 [2.0.1]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/OS2Forms/os2forms_rest_api/compare/1.1.0...2.0.0

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Response:
 To give access to webforms, you need to specify a list of API users that are
 allowed to access a webform's data via the API.
 
-Go to Settings > General > Third party settings > OS2Forms > REST API to specify
+Go to Settings > Access > View any submissions > Users to specify
 which users can access a webform's data.
 
 ### Technical details

--- a/os2forms_rest_api.module
+++ b/os2forms_rest_api.module
@@ -18,12 +18,3 @@ use Drupal\os2forms_rest_api\WebformHelper;
 function os2forms_rest_api_webform_third_party_settings_form_alter(array &$form, FormStateInterface $form_state): void {
   \Drupal::service(WebformHelper::class)->webformThirdPartySettingsFormAlter($form, $form_state);
 }
-
-/**
- * Implements hook_file_download().
- *
- * @phpstan-return int|array<string, string>|null
- */
-function os2forms_rest_api_file_download(string $uri) {
-  return \Drupal::service(WebformHelper::class)->fileDownload($uri);
-}

--- a/os2forms_rest_api.services.yml
+++ b/os2forms_rest_api.services.yml
@@ -7,8 +7,6 @@ services:
     arguments:
       - '@entity_type.manager'
       - '@current_user'
-      - '@key_auth.authentication.key_auth'
-      - '@request_stack'
 
   Drupal\os2forms_rest_api\EventSubscriber\WebformAccessEventSubscriber:
     arguments:

--- a/src/WebformHelper.php
+++ b/src/WebformHelper.php
@@ -8,10 +8,8 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
-use Drupal\key_auth\Authentication\Provider\KeyAuth;
 use Drupal\webform\WebformInterface;
 use Drupal\webform\WebformSubmissionInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Webform helper for helping with webforms.
@@ -34,27 +32,11 @@ class WebformHelper {
   private AccountProxyInterface $currentUser;
 
   /**
-   * The key authentication service.
-   *
-   * @var \Drupal\key_auth\Authentication\Provider\KeyAuth
-   */
-  private KeyAuth $keyAuth;
-
-  /**
-   * The request stack.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
-   */
-  private RequestStack $requestStack;
-
-  /**
    * Constructor.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, AccountProxyInterface $currentUser, KeyAuth $keyAuth, RequestStack $requestStack) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, AccountProxyInterface $currentUser) {
     $this->entityTypeManager = $entityTypeManager;
     $this->currentUser = $currentUser;
-    $this->keyAuth = $keyAuth;
-    $this->requestStack = $requestStack;
   }
 
   /**


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/446

* Gives users with `view_any` permission access to API.
* Updates documentation

It now only requires `view_any` permission to fully access webform data via the API. This `view_any` permission is required in order to access files attached to a submission, hence the update to documentation.