### PR TITLE
6107: Upgraded os2forms core requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ about writing changes to this log.
 
 ## [Unreleased]
 
+## [2.3.0]
+
+* Allowed `os2forms/os2forms` `5.x`.
+* Disallowed `os2forms/os2forms` `3.x`.
+
 ## [2.2.1]
 
 - Allowed `os2forms/os2forms` 4.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ about writing changes to this log.
 
 - Release 1.0.0
 
-[Unreleased]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.2.1...HEAD
+[Unreleased]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.3.0...HEAD
+[2.3.0]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/OS2Forms/os2forms_rest_api/compare/2.0.3...2.1.0

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "cweagans/composer-patches": "^1.7",
         "drupal/key_auth": "^2.0",
         "drupal/webform_rest": "^4.1",
-        "os2forms/os2forms": "^3.13 || ^4.0"
+        "os2forms/os2forms": "^4.0 || ^5.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/6107

#### Description

* Allow `os2forms`-core `5.x`
* Disallow `os2forms`-core `3.x`


> [!CAUTION]
> The current set of package requirements cannot be installed from scratch. An issue discussing this has been [created](https://github.com/OS2Forms/os2forms/issues/244). We fully expect this to work in already installed installations, hence we ignore failed GitHub Actions right at this moment.



